### PR TITLE
fix: adding correct setup for gswarms

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mavros)
 
 # Default to C++20
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD 14)
   #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a")
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -157,6 +157,9 @@ add_library(mavros_plugins SHARED
   src/plugins/sys_time.cpp
   src/plugins/waypoint.cpp
   src/plugins/wind_estimation.cpp
+
+  # ground_control_detection
+  src/plugins/ground_control_unit_detection.cpp
   # [[[end]]] (checksum: ccf56c1a56e9dccf8464483f7b1eab99)
 )
 add_dependencies(mavros_plugins

--- a/mavros/launch/px4.launch
+++ b/mavros/launch/px4.launch
@@ -1,5 +1,5 @@
 <launch>
-	<arg name="fcu_url" default="/dev/ttyACM0:57600" />
+	<arg name="fcu_url" default="/dev/ttyUSB0:57600" />
 	<arg name="gcs_url" default="" />
 	<arg name="tgt_system" default="1" />
 	<arg name="tgt_component" default="1" />

--- a/mavros/launch/px4.launch
+++ b/mavros/launch/px4.launch
@@ -1,5 +1,6 @@
 <launch>
-	<arg name="fcu_url" default="/dev/ttyUSB0:57600" />
+	<!-- <arg name="fcu_url" default="/dev/ttyACM0:57600" /> -->
+	<arg name="fcu_url" default="udp://:14540@127.0.0.1:14557" />
 	<arg name="gcs_url" default="" />
 	<arg name="tgt_system" default="1" />
 	<arg name="tgt_component" default="1" />

--- a/mavros/mavros_plugins.xml
+++ b/mavros/mavros_plugins.xml
@@ -137,5 +137,11 @@ Required by all plugins.</description>
     <description>@brief Wind estimation plugin.
 @plugin wind_estimation</description>
   </class>
+  <class name="ground_control_unit_detection" type="mavros::plugin::PluginFactoryTemplate&lt;mavros::std_plugins::GroundControlUnitDetections&gt;" base_class_type="mavros::plugin::PluginFactory">
+    <description>@brief Ground Control Unit Detection plugin
+@plugin ground_control_unit_detection
+
+Publishes detections from the ground control unit to the FCU.</description>
+  </class>
 </library>
 <!-- [[[end]]] (checksum: e47485a8565112ddf4058c7a77bcc519) -->

--- a/mavros/src/plugins/ground_control_unit_detection.cpp
+++ b/mavros/src/plugins/ground_control_unit_detection.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014 Nuno Marques.
+ * Copyright 2021 Vladimir Ermakov.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+/**
+ * @brief ground control unit detections
+ * @file ground control unit detection.cpp
+ * @author Iftach Naftaly <iftach@gswarms.com>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+
+#include "tf2_eigen/tf2_eigen.hpp"
+#include "rcpputils/asserts.hpp"
+#include "mavros/mavros_uas.hpp"
+#include "mavros/plugin.hpp"
+#include "mavros/plugin_filter.hpp"
+#include "mavros/setpoint_mixin.hpp"
+
+#include "nav_msgs/msg/odometry.hpp"
+
+namespace mavros
+{
+namespace std_plugins
+{
+using namespace std::placeholders;      // NOLINT
+
+/**
+ * @brief send ground control unit detections
+ * @plugin ground_control_unit_detection
+ *
+ * Send ground control unit detections to the FCU.
+ */
+class GroundControlUnitDetections : public plugin::Plugin,
+  private plugin::LocalPositionNEDCOVMixin<GroundControlUnitDetections>
+{
+public:
+  explicit GroundControlUnitDetections(plugin::UASPtr uas_)
+  : Plugin(uas_, "ground_control_unit")
+  {
+    node->declare_parameter("frame", std::string("local_origin_ned"));
+
+    auto sensor_qos = rclcpp::SensorDataQoS();
+
+    detection_sub = node->create_subscription<nav_msgs::msg::Odometry>(
+      "~/detection", sensor_qos, std::bind(
+        &GroundControlUnitDetections::detection_cb, this,
+        _1));
+  }
+
+  Subscriptions get_subscriptions() override
+  {
+    return { /* Rx disabled */};
+  }
+
+private:
+  friend class plugin::LocalPositionNEDCOVMixin<GroundControlUnitDetections>;
+
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr detection_sub;
+
+  /* -*- mid-level helpers -*- */
+
+  /**
+   * @brief Send ground control unit detection to FCU.
+   *
+   * @warning Send only AFX AFY AFZ. ENU frame.
+   */
+  void send_detection(const rclcpp::Time & stamp, const Eigen::Vector3d & position_ned, const Eigen::Vector3d & velocity_ned, const uint8_t child_frame_id)
+  {
+
+    std::string _frame;
+    node->get_parameter("frame", _frame);
+
+    Eigen::Matrix<float, 1, 9> p_cov;
+    p_cov.setZero();  // Initialize all elements to 0
+
+    Eigen::Matrix<float, 1, 9> v_cov;
+    v_cov.setZero();  // Initialize all elements to 0
+
+    local_position_ned_cov(
+      get_time_boot_ms(stamp),
+      child_frame_id,
+      position_ned,
+      velocity_ned,
+      p_cov,
+      v_cov);
+  }
+
+  /* -*- callbacks -*- */
+
+  void detection_cb(const nav_msgs::msg::Odometry::SharedPtr req)
+  {
+    Eigen::Vector3d position_ned;
+    Eigen::Vector3d velocity_ned;
+    uint8_t child_frame_id;
+
+    child_frame_id = static_cast<uint8_t>(std::stoi(req->child_frame_id));
+
+    position_ned[0] = req->pose.pose.position.x;
+    position_ned[1] = req->pose.pose.position.y;
+    position_ned[2] = req->pose.pose.position.z;
+
+    velocity_ned[0] = req->twist.twist.linear.x;
+    velocity_ned[1] = req->twist.twist.linear.y;
+    velocity_ned[2] = req->twist.twist.linear.z;
+
+    this->send_detection(req->header.stamp, position_ned, velocity_ned, child_frame_id);
+  }
+};
+
+}       // namespace std_plugins
+}       // namespace mavros
+
+#include <mavros/mavros_plugin_register_macro.hpp>  // NOLINT
+MAVROS_PLUGIN_REGISTER(mavros::std_plugins::GroundControlUnitDetections)

--- a/mavros/src/plugins/ground_control_unit_detection.cpp
+++ b/mavros/src/plugins/ground_control_unit_detection.cpp
@@ -51,6 +51,8 @@ public:
       "/ground_control_unit/detection", sensor_qos, std::bind(
         &GroundControlUnitDetections::detection_cb, this,
         _1));
+
+    RCLCPP_INFO(node->get_logger(), "Ground Control Unit Plugin initialized");
   }
 
   Subscriptions get_subscriptions() override

--- a/mavros/src/plugins/ground_control_unit_detection.cpp
+++ b/mavros/src/plugins/ground_control_unit_detection.cpp
@@ -48,7 +48,7 @@ public:
     auto sensor_qos = rclcpp::SensorDataQoS();
 
     detection_sub = node->create_subscription<nav_msgs::msg::Odometry>(
-      "~/detection", sensor_qos, std::bind(
+      "/ground_control_unit/detection", sensor_qos, std::bind(
         &GroundControlUnitDetections::detection_cb, this,
         _1));
   }


### PR DESCRIPTION
This pull request introduces several significant changes to the `mavros` project, including the addition of a new plugin for ground control unit detection, a modification to the C++ standard used, and updates to launch configuration files. Below are the most important changes grouped by theme:

### New Plugin Addition:
* Added a new plugin for ground control unit detection, including its implementation in `mavros/src/plugins/ground_control_unit_detection.cpp`. This plugin publishes detections from the ground control unit to the FCU.
* Updated `mavros/mavros_plugins.xml` to include the new `ground_control_unit_detection` plugin.
* Included the new plugin source file in the `mavros/CMakeLists.txt`.

### Build Configuration:
* Changed the default C++ standard from C++20 to C++14 in `mavros/CMakeLists.txt`.

### Launch Configuration:
* Modified the `px4.launch` file to change the default `fcu_url` from a serial connection to a UDP connection.

### Code Enhancements:
* Added `LocalPositionNEDCOVMixin` class to `mavros/include/mavros/setpoint_mixin.hpp` for handling local position NED covariance messages.